### PR TITLE
Only remove the old image if old image exists

### DIFF
--- a/src/Backend/Modules/Links/Actions/EditCategory.php
+++ b/src/Backend/Modules/Links/Actions/EditCategory.php
@@ -195,10 +195,12 @@ class EditCategory extends BackendBaseActionEdit
 					// new image given?
 					if($this->frm->getField('logo')->isFilled())
 					{
-						// delete the old image
-						$fs = new Filesystem();
-						$fs->remove($imagePath . '/source/' . $item['logo']);
-						$fs->remove($imagePath . '/128x128/' . $item['logo']);
+						if($item['logo'] !== null) {
+							// delete the old image
+							$fs = new Filesystem();
+							$fs->remove($imagePath . '/source/' . $item['logo']);
+							$fs->remove($imagePath . '/128x128/' . $item['logo']);	
+						}
 
 						// build the image name
 						$item['logo'] = time() . '.' . $this->frm->getField('logo')->getExtension();


### PR DESCRIPTION
When I create a category and then edit it and add an image, the folders source and 128x128 are deleted because $item['logo'] is null. So only delete the old image if there exists an old image